### PR TITLE
Adds Travis CI config and fixes several problems break builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/brpc-java-core/pom.xml
+++ b/brpc-java-core/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javastruct</groupId>

--- a/brpc-java-core/pom.xml
+++ b/brpc-java-core/pom.xml
@@ -91,10 +91,6 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javastruct</groupId>
-            <artifactId>javastruct</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
         </dependency>

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
@@ -485,7 +485,7 @@ public class RpcClient {
                         while (iter.hasNext()) {
                             BrpcChannelGroup instance = iter.next();
                             boolean isHealthy = isInstanceHealthy(instance.getIp(), instance.getPort());
-                            if (isHealthy) {
+                            if (!isHealthy) {
                                 newUnhealthyInstances.add(instance);
                             }
                         }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -203,7 +203,7 @@ public class RpcServer {
                     port = Integer.valueOf(System.getenv(rpcServerOptions.getJarvisPortName()));
                 }
             }
-            ChannelFuture channelFuture = bootstrap.bind("0.0.0.0", port);
+            ChannelFuture channelFuture = bootstrap.bind(port);
             channelFuture.sync();
             if (namingService != null) {
                 for (RegisterInfo registerInfo : registerInfoList) {

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -203,7 +203,7 @@ public class RpcServer {
                     port = Integer.valueOf(System.getenv(rpcServerOptions.getJarvisPortName()));
                 }
             }
-            ChannelFuture channelFuture = bootstrap.bind(port);
+            ChannelFuture channelFuture = bootstrap.bind("0.0.0.0", port);
             channelFuture.sync();
             if (namingService != null) {
                 for (RegisterInfo registerInfo : registerInfoList) {

--- a/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NSHeadTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NSHeadTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.baidu.brpc.protocol.nshead;
+
+import com.baidu.brpc.exceptions.BadSchemaException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class NSHeadTest {
+
+    @Test
+    public void fromByteBuf() throws BadSchemaException {
+        byte[] bytes = new byte[]{
+                -22, 0, 1, 0, 123, 0, 0, 0, 108, 111, 110, 103, 101, 114, 45, 116, 104,
+                97, 110, 45, 115, 105, 120, 116, -108, -109, 112, -5, 0, 0, 0, 0, 41, 9, 0, 0
+        };
+        ByteBuf buf = Unpooled.wrappedBuffer(bytes);
+        NSHead head = NSHead.fromByteBuf(buf);
+        assertThat(head.id, equalTo((short) 234));
+        assertThat(head.logId, equalTo(123));
+        assertThat(head.version, equalTo((short) 1));
+        assertThat(head.provider, equalTo("longer-than-sixt")); // een discard
+        assertThat(head.bodyLength, equalTo(2345));
+    }
+
+    @Test
+    public void toBytes() {
+        byte[] bytes = new byte[]{
+                -22, 0, 1, 0, 123, 0, 0, 0, 108, 111, 110, 103, 101, 114, 45, 116, 104,
+                97, 110, 45, 115, 105, 120, 116, -108, -109, 112, -5, 0, 0, 0, 0, 41, 9, 0, 0
+        };
+        NSHead head = new NSHead(123, (short) 234, (short) 1, "longer-than-sixteen", 2345);
+        byte[] serialized = head.toBytes();
+        assertThat(serialized, equalTo(bytes));
+    }
+}

--- a/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NsHeadRpcProtocolProtobufTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NsHeadRpcProtocolProtobufTest.java
@@ -52,13 +52,10 @@ public class NsHeadRpcProtocolProtobufTest {
 
         ByteBuf byteBuf = protocol.encodeRequest(rpcRequest);
 
-        byte[] nshead = new byte[NSHead.NSHEAD_LENGTH];
-        byteBuf.readBytes(nshead);
-
-        NSHead nsHead = decodeNshead(nshead);
+        NSHead nsHead = NSHead.fromByteBuf(byteBuf);
 
         assertEquals(3, nsHead.logId);
-        assertEquals("", nsHead.provider.toString());
+        assertEquals("", nsHead.provider);
         assertEquals(byteBuf.readableBytes(), nsHead.bodyLength);
     }
 
@@ -97,26 +94,11 @@ public class NsHeadRpcProtocolProtobufTest {
 
         ByteBuf byteBuf = protocol.encodeResponse(rpcResponse);
 
-        byte[] nshead = new byte[NSHead.NSHEAD_LENGTH];
-        byteBuf.readBytes(nshead);
-
-        NSHead nsHead = decodeNshead(nshead);
+        NSHead nsHead = NSHead.fromByteBuf(byteBuf);
 
         assertEquals(4, nsHead.logId);
         assertEquals(byteBuf.readableBytes(), nsHead.bodyLength);
     }
-
-
-
-    private NSHead decodeNshead(byte[] bytes) throws Exception {
-        Method method = protocol.getClass().getDeclaredMethod("decodeNSHead", bytes.getClass());
-        method.setAccessible(true);
-        Object r = method.invoke(protocol, bytes);
-
-        return (NSHead) r;
-    }
-
-
 
     private byte[] encodeBody(Object body, Method invokeMethod) throws Exception {
 
@@ -126,6 +108,4 @@ public class NsHeadRpcProtocolProtobufTest {
 
         return (byte[]) r;
     }
-
-
 }

--- a/brpc-java-spring/pom.xml
+++ b/brpc-java-spring/pom.xml
@@ -1,39 +1,49 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.baidu</groupId>
-		<artifactId>brpc-java-parent</artifactId>
-		<version>2.0.0</version>
-	</parent>
-	<artifactId>brpc-java-spring</artifactId>
-	<packaging>jar</packaging>
-	<name>${project.artifactId}</name>
-	<description>The module for Spring extendsion</description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.baidu</groupId>
+        <artifactId>brpc-java-parent</artifactId>
+        <version>2.0.0</version>
+    </parent>
+    <artifactId>brpc-java-spring</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>The module for Spring extendsion</description>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-web.version>3.2.11.RELEASE</spring-web.version>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-web.version>3.2.11.RELEASE</spring-web.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.baidu</groupId>
-			<artifactId>brpc-java</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
-			<version>${spring-web.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-			<version>${spring-web.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>com.baidu</groupId>
+            <artifactId>brpc-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring-web.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring-web.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/brpc-java-spring/src/test/resources/com/baidu/brpc/spring/HaRpcXmlConfigurationTest.xml
+++ b/brpc-java-spring/src/test/resources/com/baidu/brpc/spring/HaRpcXmlConfigurationTest.xml
@@ -43,5 +43,6 @@
 	<bean id="echoServiceProxy" class="com.baidu.brpc.spring.RpcProxyFactoryBean">
 		<property name="serviceInterface" value="com.baidu.brpc.spring.EchoService"></property>
 		<property name="serviceUrl" value="list://127.0.0.1:1031,127.0.0.1:1032,127.0.0.1:1033"></property>
+		<property name="healthyCheckIntervalMillis" value="3000"/>
 	</bean>
 </beans>

--- a/brpc-java-spring/src/test/resources/log4j2.xml
+++ b/brpc-java-spring/src/test/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %p [%t]\t%m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.baidu.brpc" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javastruct</groupId>
-                <artifactId>javastruct</artifactId>
-                <version>0.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>1.1.7.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,9 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>3.1</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>javastruct</groupId>


### PR DESCRIPTION
Adds a minimal `.travis.yml` file to trigger the Travis CI build, it will run `mvn test -B` after each repo push.

Following problems have been resolved so we can have a successful build:

- `javax.servlet:servlet-api:3.1' is missing in Maven Central, replaced with `javax.servlet:javax.servlet-api:3.1.0' instead
- `javastruct:javastruct:0.1' is missing in Maven Central, dropped this dependency and implemented parsing/serializing using `ByteBuf/ByteBuffer` API
- Fixed a bug in server health checker
