### PR TITLE
fixed HttpRpcservlet response getRpcMethodInfo null Exception

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcServlet.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcServlet.java
@@ -88,6 +88,8 @@ public class HttpRpcServlet extends HttpServlet {
             request = protocol.decodeRequest(httpRequest);
             Object result = request.getTargetMethod().invoke(request.getTarget(), request.getArgs()[0]);
             response.setResult(result);
+            response.setRpcMethodInfo(request.getRpcMethodInfo());
+            response.setLogId(request.getLogId());
             protocol.encodeResponse(request, response);
         } catch (Exception ex) {
             errorMsg = String.format("invoke method failed, msg=%s", ex.getMessage());


### PR DESCRIPTION
在encodeResponse时需要通过response的RpcMethodInfo获取返回值类型等，需要提前设置
另，在request中已经获取到logId，需要用这个来设置response中的logId