### PR TITLE
Rm apache bean utils

### DIFF
--- a/brpc-java-core/pom.xml
+++ b/brpc-java-core/pom.xml
@@ -83,10 +83,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/BrpcProxy.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/BrpcProxy.java
@@ -24,19 +24,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.collections.CollectionUtils;
-
 import com.baidu.brpc.JprotobufRpcMethodInfo;
 import com.baidu.brpc.ProtobufRpcMethodInfo;
 import com.baidu.brpc.RpcMethodInfo;
 import com.baidu.brpc.exceptions.RpcException;
-import com.baidu.brpc.interceptor.Interceptor;
 import com.baidu.brpc.naming.NamingOptions;
 import com.baidu.brpc.protocol.Request;
 import com.baidu.brpc.protocol.RpcContext;
 import com.baidu.brpc.utils.ProtobufUtils;
-
 import lombok.extern.slf4j.Slf4j;
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
@@ -135,6 +130,7 @@ public class BrpcProxy implements MethodInterceptor {
         return (T) en.create();
     }
 
+    @Override
     public Object intercept(Object obj, Method method, Object[] args,
                             MethodProxy proxy) throws Throwable {
         String methodName = method.getName();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClientOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClientOptions.java
@@ -19,8 +19,9 @@ package com.baidu.brpc.client;
 import com.baidu.brpc.client.channel.ChannelType;
 import com.baidu.brpc.client.loadbalance.LoadBalanceType;
 import com.baidu.brpc.protocol.Options;
-
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -28,71 +29,76 @@ import lombok.Setter;
  */
 @Setter
 @Getter
+@NoArgsConstructor
 public class RpcClientOptions {
-
     private int protocolType = Options.ProtocolType.PROTOCOL_BAIDU_STD_VALUE;
-
     private int connectTimeoutMillis = 1000;
-
     private int readTimeoutMillis = 1000;
-
     private int writeTimeoutMillis = 1000;
-
     private int maxTotalConnections = 8;
-
     private int minIdleConnections = 8;
-
     private int maxTryTimes = 3;
-
     // Maximum time for connection idle, testWhileIdle needs to be true
     private long timeBetweenEvictionRunsMillis = 5 * 60 * 1000;
-
     private int loadBalanceType = LoadBalanceType.ROUND_ROBIN.getId();
-
     // for fair load balance strategy only
     private int latencyWindowSizeOfFairLoadBalance = 30;
-
     // for fair load balance strategy only
     // the ratio of activeInstancesNum/totalInstancesNum in brpc client, if this ratio not reached,
     // fair load balance will not start, just use random load balance strategy
     private float activeInstancesRatioOfFairLoadBalance = 0.5f;
-
     private int healthyCheckIntervalMillis = 3000;
-
     // The keep alive
     private boolean keepAlive = true;
-
     private boolean reuseAddr = true;
-
     private boolean tcpNoDelay = true;
-
     // so linger
     private int soLinger = 5;
-
     // backlog
     private int backlog = 100;
-
     // receive buffer size
     private int receiveBufferSize = 1024 * 64;
-
     // send buffer size
     private int sendBufferSize = 1024 * 64;
-
     // keep alive time in seconds
-    private int keepAliveTime =  60 * 5;
-
+    private int keepAliveTime = 60 * 5;
     // io threads, default use Netty default value
     private int ioThreadNum = Runtime.getRuntime().availableProcessors();
-
     // threads used for deserialize rpc response and execute the callback
     private int workThreadNum = Runtime.getRuntime().availableProcessors();
-
     // FastFutureStore's max size
     private int futureBufferSize = 1000000;
-
     private String encoding = "utf-8";
-
     private Options.CompressType compressType = Options.CompressType.COMPRESS_TYPE_NONE;
-
     private ChannelType channelType = ChannelType.POOLED_CONNECTION;
+
+
+    public void copyFrom(RpcClientOptions another) {
+        this.activeInstancesRatioOfFairLoadBalance = another.activeInstancesRatioOfFairLoadBalance;
+        this.backlog = another.backlog;
+        this.channelType = another.channelType;
+        this.compressType = another.compressType;
+        this.connectTimeoutMillis = another.connectTimeoutMillis;
+        this.encoding = another.encoding;
+        this.futureBufferSize = another.futureBufferSize;
+        this.healthyCheckIntervalMillis = another.healthyCheckIntervalMillis;
+        this.ioThreadNum = another.ioThreadNum;
+        this.keepAlive = another.keepAlive;
+        this.keepAliveTime = another.keepAliveTime;
+        this.latencyWindowSizeOfFairLoadBalance = another.latencyWindowSizeOfFairLoadBalance;
+        this.loadBalanceType = another.loadBalanceType;
+        this.maxTotalConnections = another.maxTotalConnections;
+        this.maxTryTimes = another.maxTryTimes;
+        this.minIdleConnections = another.minIdleConnections;
+        this.protocolType = another.protocolType;
+        this.readTimeoutMillis = another.readTimeoutMillis;
+        this.receiveBufferSize = another.receiveBufferSize;
+        this.reuseAddr = another.reuseAddr;
+        this.sendBufferSize = another.sendBufferSize;
+        this.soLinger = another.soLinger;
+        this.tcpNoDelay = another.tcpNoDelay;
+        this.timeBetweenEvictionRunsMillis = another.timeBetweenEvictionRunsMillis;
+        this.workThreadNum = another.workThreadNum;
+        this.writeTimeoutMillis = another.writeTimeoutMillis;
+    }
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcFuture.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcFuture.java
@@ -21,8 +21,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.baidu.brpc.utils.CollectionUtils;
 import lombok.AccessLevel;
-import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/loadbalance/FairStrategy.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/loadbalance/FairStrategy.java
@@ -16,24 +16,22 @@
 
 package com.baidu.brpc.client.loadbalance;
 
+import com.baidu.brpc.client.RpcClient;
+import com.baidu.brpc.client.channel.BrpcChannelGroup;
+import com.baidu.brpc.utils.CollectionUtils;
+import com.baidu.brpc.utils.CustomThreadFactory;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timeout;
+import io.netty.util.Timer;
+import io.netty.util.TimerTask;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.collections.CollectionUtils;
-
-import com.baidu.brpc.client.RpcClient;
-import com.baidu.brpc.client.channel.BrpcChannelGroup;
-import com.baidu.brpc.utils.CustomThreadFactory;
-
-import io.netty.util.HashedWheelTimer;
-import io.netty.util.Timeout;
-import io.netty.util.Timer;
-import io.netty.util.TimerTask;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Fair load balance strategy aims to more reasonable distribution of traffic.
@@ -87,7 +85,7 @@ public class FairStrategy implements LoadBalanceStrategy {
     @Override
     public void init(RpcClient rpcClient) {
         if (timer == null) {
-            synchronized(this) {
+            synchronized (this) {
                 if (timer == null) {
                     timer = new HashedWheelTimer(new CustomThreadFactory("fairStrategy-timer-thread"));
                     timer.newTimeout(new TimerTask() {
@@ -254,7 +252,6 @@ public class FairStrategy implements LoadBalanceStrategy {
      *
      * @param group   The BrpcChannelGroup instance of a rpc server
      * @param timeOut Read timeout in millis
-     *
      * @return Weight num
      */
     protected int calculateWeight(BrpcChannelGroup group, int timeOut) {
@@ -278,7 +275,6 @@ public class FairStrategy implements LoadBalanceStrategy {
      * the parent nodes used to calculate the sum of it's children's weight
      *
      * @param leafNodes leaf nodes list
-     *
      * @return the root node of the tree
      */
     protected Node generateWeightTreeByLeafNodes(Queue<Node> leafNodes) {
@@ -322,6 +318,8 @@ public class FairStrategy implements LoadBalanceStrategy {
      * The weight tree node
      */
     static class Node {
+        // empty node
+        static Node none = new Node();
         int serverId;
         int weight;
         boolean isLeaf;
@@ -329,8 +327,6 @@ public class FairStrategy implements LoadBalanceStrategy {
         Node left;
         Node right;
         BrpcChannelGroup server;
-        // empty node
-        static Node none = new Node();
 
         public Node() {
         }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -18,12 +18,6 @@ package com.baidu.brpc.server;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.baidu.brpc.interceptor.Interceptor;
 import com.baidu.brpc.naming.BrpcURL;
 import com.baidu.brpc.naming.NamingOptions;
@@ -40,7 +34,6 @@ import com.baidu.brpc.thread.ShutDownManager;
 import com.baidu.brpc.utils.CustomThreadFactory;
 import com.baidu.brpc.utils.NetUtils;
 import com.baidu.brpc.utils.ThreadPool;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
@@ -57,6 +50,9 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by wenweihu86 on 2017/4/24.
@@ -104,7 +100,7 @@ public class RpcServer {
         this.port = port;
         if (options != null) {
             try {
-                BeanUtils.copyProperties(this.rpcServerOptions, options);
+                this.rpcServerOptions.copyFrom(options);
             } catch (Exception ex) {
                 LOG.warn("init options failed, so use default");
             }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
@@ -19,6 +19,7 @@ package com.baidu.brpc.server;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -28,63 +29,67 @@ import lombok.ToString;
 @Setter
 @Getter
 @ToString
+@NoArgsConstructor
 public class RpcServerOptions {
-
     // The keep alive
     private boolean keepAlive = true;
-
     private boolean tcpNoDelay = true;
-
     // so linger
     private int soLinger = 5;
-
     // backlog
     private int backlog = 1024;
-
     // receive buffer size
     private int receiveBufferSize = 1024 * 64;
-
     // send buffer size
     private int sendBufferSize = 1024 * 64;
-
     /**
      * an {@link IdleStateEvent} whose state is {@link IdleState#READER_IDLE}
      * will be triggered when no read was performed for the specified period of time.
      * Specify {@code 0} to disable.
      */
     private int readerIdleTime = 60;
-
     /**
      * an {@link IdleStateEvent} whose state is {@link IdleState#WRITER_IDLE}
      * will be triggered when no write was performed for the specified period of time.
      * Specify {@code 0} to disable.
      */
     private int writerIdleTime = 60;
-
     // keepAlive时间（second）
     private int keepAliveTime = 5;
-
     // acceptor threads, default use Netty default value
     private int acceptorThreadNum = 1;
-
     // io threads, default use Netty default value
     private int ioThreadNum = Runtime.getRuntime().availableProcessors();
-
     // real work threads
     private int workThreadNum = Runtime.getRuntime().availableProcessors();
-
     // The max size
     private int maxSize = Integer.MAX_VALUE;
-
     // server protocol type
     private Integer protocolType;
-
     private String encoding = "utf-8";
-
     // bns port name when deploys on Jarvis environment
     private String jarvisPortName;
-
     // naming service url
     private String namingServiceUrl = "";
+
+    public void copyFrom(RpcServerOptions options) {
+        this.acceptorThreadNum = options.acceptorThreadNum;
+        this.backlog = options.backlog;
+        this.encoding = options.encoding;
+        this.ioThreadNum = options.ioThreadNum;
+        this.jarvisPortName = options.jarvisPortName;
+        this.keepAlive = options.keepAlive;
+        this.keepAliveTime = options.keepAliveTime;
+        this.maxSize = options.maxSize;
+        this.namingServiceUrl = options.namingServiceUrl;
+        this.protocolType = options.protocolType;
+        this.readerIdleTime = options.readerIdleTime;
+        this.receiveBufferSize = options.receiveBufferSize;
+        this.sendBufferSize = options.sendBufferSize;
+        this.soLinger = options.soLinger;
+        this.tcpNoDelay = options.tcpNoDelay;
+        this.workThreadNum = options.workThreadNum;
+        this.writerIdleTime = options.writerIdleTime;
+    }
 
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/ServerWorkTask.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/ServerWorkTask.java
@@ -24,7 +24,6 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 import com.baidu.brpc.interceptor.JoinPoint;
 import com.baidu.brpc.server.ServerJoinPoint;
-import org.apache.commons.collections.CollectionUtils;
 
 import com.baidu.brpc.exceptions.RpcException;
 import com.baidu.brpc.interceptor.Interceptor;
@@ -36,6 +35,7 @@ import com.baidu.brpc.protocol.http.HttpRpcProtocol;
 import com.baidu.brpc.server.RpcServer;
 import com.baidu.brpc.server.ServerStatus;
 
+import com.baidu.brpc.utils.CollectionUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;

--- a/brpc-java-core/src/main/java/com/baidu/brpc/utils/CollectionUtils.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/utils/CollectionUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baidu.brpc.utils;
+
+import java.util.Collection;
+
+/**
+ * Utility methods for {@link Collection} instances.
+ *
+ * @author guohaoice@gmail.com
+ */
+public final class CollectionUtils {
+
+    /**
+     * Null-safe check if the specified collection is empty.
+     *
+     * @param collection the collection to check, may be null
+     * @return true if empty or null
+     */
+    public static boolean isEmpty(Collection<?> collection) {
+        return null == collection || collection.isEmpty();
+    }
+
+    /**
+     * Null-safe check if the specified collection is not empty.
+     *
+     * @param collection the collection to check, may be null
+     * @return true if non-null and non-empty
+     */
+    public static boolean isNotEmpty(Collection<?> collection) {
+        return !isEmpty(collection);
+    }
+}

--- a/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcAnnotationResolver.java
+++ b/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcAnnotationResolver.java
@@ -24,15 +24,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
+import com.baidu.bjf.remoting.protobuf.utils.JDKCompilerHelper;
+import com.baidu.bjf.remoting.protobuf.utils.compiler.Compiler;
 import com.baidu.brpc.client.RpcClientOptions;
 import com.baidu.brpc.interceptor.Interceptor;
 import com.baidu.brpc.naming.DefaultNamingServiceFactory;
 import com.baidu.brpc.naming.NamingServiceFactory;
 import com.baidu.brpc.server.RpcServerOptions;
+import com.baidu.brpc.spring.RpcProxyFactoryBean;
+import com.baidu.brpc.spring.RpcServiceExporter;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -42,11 +44,6 @@ import org.springframework.beans.PropertyValues;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-
-import com.baidu.bjf.remoting.protobuf.utils.JDKCompilerHelper;
-import com.baidu.brpc.spring.RpcProxyFactoryBean;
-import com.baidu.brpc.spring.RpcServiceExporter;
-import com.baidu.bjf.remoting.protobuf.utils.compiler.Compiler;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 
@@ -60,36 +57,52 @@ import org.springframework.beans.factory.support.GenericBeanDefinition;
 @Getter
 public class RpcAnnotationResolver extends AbstractAnnotationParserCallback implements InitializingBean {
 
-    /** log this class. */
+    /**
+     * log this class.
+     */
     protected static final Log LOGGER = LogFactory.getLog(RpcAnnotationResolver.class);
 
-    /** The rpc clients. */
+    /**
+     * The rpc clients.
+     */
     private List<RpcProxyFactoryBean> rpcClients = new ArrayList<RpcProxyFactoryBean>();
 
-    /** The port mapping expoters. */
+    /**
+     * The port mapping expoters.
+     */
     private Map<Integer, RpcServiceExporter> portMappingExpoters = new HashMap<Integer, RpcServiceExporter>();
 
-    /** The compiler. */
+    /**
+     * The compiler.
+     */
     private Compiler compiler;
 
-    /** status to control start only once. */
+    /**
+     * status to control start only once.
+     */
     private AtomicBoolean started = new AtomicBoolean(false);
 
     /* the default naming service url */
     private String namingServiceUrl;
 
-    /** The default registry center service for all service */
+    /**
+     * The default registry center service for all service
+     */
     private NamingServiceFactory namingServiceFactory;
 
-    /** The default interceptor for all service */
+    /**
+     * The default interceptor for all service
+     */
     private Interceptor interceptor;
 
-    /** The protobuf rpc annotation resolver listener. */
+    /**
+     * The protobuf rpc annotation resolver listener.
+     */
     private RpcAnnotationResolverListener protobufRpcAnnotationRessolverListener;
 
     @Override
     public Object annotationAtType(Annotation t, Object bean, String beanName,
-            ConfigurableListableBeanFactory beanFactory) throws BeansException {
+                                   ConfigurableListableBeanFactory beanFactory) throws BeansException {
         if (t instanceof RpcExporter) {
             LOGGER.info("Annotation 'RpcExporter' for target '" + beanName + "' created");
 
@@ -105,10 +118,10 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
      *
      * @param rpcExporter the rpc exporter
      * @param beanFactory the bean factory
-     * @param bean the bean
+     * @param bean        the bean
      */
     private void parseRpcExporterAnnotation(RpcExporter rpcExporter, ConfigurableListableBeanFactory beanFactory,
-            Object bean) {
+                                            Object bean) {
 
         String port = parsePlaceholder(rpcExporter.port());
         // convert to integer and throw exception on error
@@ -135,7 +148,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
             }
 
             try {
-                BeanUtils.copyProperties(rpcServiceExporter, rpcServerOptions);
+                rpcServiceExporter.copyFrom(rpcServerOptions);
             } catch (Exception ex) {
                 throw new RuntimeException("copy server options failed:", ex);
             }
@@ -189,7 +202,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     @Override
     public void annotationAtTypeAfterStarted(Annotation t, Object bean, String beanName,
-            ConfigurableListableBeanFactory beanFactory) throws BeansException {
+                                             ConfigurableListableBeanFactory beanFactory) throws BeansException {
 
         if (started.compareAndSet(false, true)) {
             // do export service here
@@ -206,7 +219,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.baidu.brpc.spring.annotation.AnnotationParserCallback#
      * annotationAtField(java.lang.annotation. Annotation, java.lang.Object, java.lang.String,
      * org.springframework.beans.PropertyValues,
@@ -214,7 +227,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
      */
     @Override
     public Object annotationAtField(Annotation t, Object value, String beanName, PropertyValues pvs,
-            DefaultListableBeanFactory beanFactory, Field field) throws BeansException {
+                                    DefaultListableBeanFactory beanFactory, Field field) throws BeansException {
         if (t instanceof RpcProxy) {
             try {
                 LOGGER.info("Annotation 'BrpcProxy' on field '" + field.getName() + "' for target '" + beanName
@@ -231,7 +244,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
     /**
      * Parses the rpc proxy annotation.
      *
-     * @param rpcProxy the rpc proxy
+     * @param rpcProxy    the rpc proxy
      * @param beanFactory the bean factory
      * @return the object
      * @throws Exception the exception
@@ -288,8 +301,8 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
     /**
      * Creates the rpc proxy factory bean.
      *
-     * @param rpcProxy the rpc proxy
-     * @param beanFactory the bean factory
+     * @param rpcProxy         the rpc proxy
+     * @param beanFactory      the bean factory
      * @param rpcClientOptions the rpc client options
      * @param namingServiceUrl naming service url
      * @return the rpc proxy factory bean
@@ -350,7 +363,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.baidu.jprotobuf.pbrpc.spring.annotation.AnnotationParserCallback#
      * annotationAtMethod(java.lang.annotation. Annotation, java.lang.Object, java.lang.String,
      * org.springframework.beans.PropertyValues,
@@ -358,7 +371,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
      */
     @Override
     public Object annotationAtMethod(Annotation t, Object bean, String beanName, PropertyValues pvs,
-            DefaultListableBeanFactory beanFactory, Method method) throws BeansException {
+                                     DefaultListableBeanFactory beanFactory, Method method) throws BeansException {
         if (t instanceof RpcProxy) {
             try {
                 LOGGER.info("Annotation 'BrpcProxy' on method '" + method.getName() + "' for target '" + beanName
@@ -374,7 +387,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.baidu.brpc.spring.annotation.AnnotationParserCallback# getTypeAnnotation()
      */
     @Override
@@ -384,7 +397,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.baidu.brpc.spring.annotation.AnnotationParserCallback# getMethodFieldAnnotation()
      */
     @Override
@@ -437,7 +450,7 @@ public class RpcAnnotationResolver extends AbstractAnnotationParserCallback impl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
      */
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -299,11 +299,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.9.3</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>


### PR DESCRIPTION
1. BeanUtils is slow and costly when copies properties.
2. A dependency should be evicted if we rarely use its methods, such as `CollectionUtils.isEmpty()`
3. Some optimization of code format . 