### PR TITLE
Threadpool isolation

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/RpcMethodInfo.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/RpcMethodInfo.java
@@ -46,7 +46,6 @@ public class RpcMethodInfo {
     // instance of interface which method belongs to
     protected Object target;
     protected boolean includeController;
-
     protected ThreadPool threadPool;
 
     public RpcMethodInfo(Method method) {

--- a/brpc-java-core/src/main/java/com/baidu/brpc/RpcMethodInfo.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/RpcMethodInfo.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Type;
 import com.baidu.brpc.buffer.DynamicCompositeByteBuf;
 import com.baidu.brpc.protocol.nshead.NSHeadMeta;
 import com.baidu.brpc.utils.RpcMetaUtils;
+import com.baidu.brpc.utils.ThreadPool;
 import com.google.protobuf.CodedOutputStream;
 
 import io.netty.buffer.ByteBuf;
@@ -45,6 +46,8 @@ public class RpcMethodInfo {
     // instance of interface which method belongs to
     protected Object target;
     protected boolean includeController;
+
+    protected ThreadPool threadPool;
 
     public RpcMethodInfo(Method method) {
         RpcMetaUtils.RpcMetaInfo metaInfo = RpcMetaUtils.parseRpcMeta(method);

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcFuture.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcFuture.java
@@ -57,11 +57,13 @@ public class RpcFuture<T> implements AsyncAwareFuture<T> {
 
     public RpcFuture() {
         this.latch = new CountDownLatch(1);
+        this.startTime = System.currentTimeMillis();
     }
 
     public RpcFuture(long logId) {
         this.logId = logId;
         this.latch = new CountDownLatch(1);
+        this.startTime = System.currentTimeMillis();
     }
 
     public RpcFuture(Timeout timeout,

--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/handler/RpcClientHandler.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/handler/RpcClientHandler.java
@@ -78,14 +78,15 @@ public class RpcClientHandler extends SimpleChannelInboundHandler<Object> {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         final ChannelInfo channelInfo = ChannelInfo.getClientChannelInfo(ctx.channel());
+        String ip = channelInfo.getChannelGroup().getIp();
+        int port = channelInfo.getChannelGroup().getPort();
+        final String errMsg = String.format("channel is non active, ip=%s,port=%d", ip, port);
+        log.debug(errMsg);
 
         if (channelInfo != null) {
             rpcClient.triggerCallback(new Runnable() {
                 @Override
                 public void run() {
-                    String ip = channelInfo.getChannelGroup().getIp();
-                    int port = channelInfo.getChannelGroup().getPort();
-                    String errMsg = String.format("channel is non active, ip=%s,port=%d", ip, port);
                     RpcException ex = new RpcException(RpcException.NETWORK_EXCEPTION, errMsg);
                     channelInfo.handleChannelException(ex);
                 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcProtocol.java
@@ -303,7 +303,7 @@ public class HttpRpcProtocol extends AbstractProtocol {
     @Override
     public Request decodeRequest(Object packet) {
         try {
-            HttpRequest httpRequest = (HttpRequest) this.getRequest();
+            HttpRequest httpRequest = (HttpRequest) this.createRequest();
             httpRequest.setMsg(packet);
             long logId = parseLogId(httpRequest.headers().get(LOG_ID), null);
             httpRequest.setLogId(logId);

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcServlet.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcServlet.java
@@ -52,12 +52,12 @@ public class HttpRpcServlet extends HttpServlet {
 
     public void registerService(Object service) {
         ServiceManager serviceManager = ServiceManager.getInstance();
-        serviceManager.registerService(service);
+        serviceManager.registerService(service, null);
     }
 
     public void registerService(Class targetClass, Object service) {
         ServiceManager serviceManager = ServiceManager.getInstance();
-        serviceManager.registerService(targetClass, service);
+        serviceManager.registerService(targetClass, service, null);
     }
 
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/hulu/HuluRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/hulu/HuluRpcProtocol.java
@@ -188,7 +188,7 @@ public class HuluRpcProtocol extends AbstractProtocol {
 
     @Override
     public Request decodeRequest(Object packet) throws Exception {
-        Request request = this.getRequest();
+        Request request = this.createRequest();
         HuluRpcDecodePacket requestPacket = (HuluRpcDecodePacket) packet;
         ByteBuf metaBuf = requestPacket.getMetaBuf();
         ByteBuf protoAndAttachmentBuf = requestPacket.getProtoAndAttachmentBuf();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/nshead/NSHeadRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/nshead/NSHeadRpcProtocol.java
@@ -110,7 +110,7 @@ public class NSHeadRpcProtocol extends AbstractProtocol {
 
     @Override
     public Request decodeRequest(Object packet) throws Exception {
-        Request request = this.getRequest();
+        Request request = this.createRequest();
         NSHeadPacket nsHeadPacket = (NSHeadPacket) packet;
         request.setLogId((long) nsHeadPacket.getNsHead().logId);
 

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/sofa/SofaRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/sofa/SofaRpcProtocol.java
@@ -188,7 +188,7 @@ public class SofaRpcProtocol extends AbstractProtocol {
 
     @Override
     public Request decodeRequest(Object packet) throws Exception {
-        Request request = this.getRequest();
+        Request request = this.createRequest();
         SofaRpcDecodePacket requestPacket = (SofaRpcDecodePacket) packet;
         ByteBuf metaBuf = requestPacket.getMetaBuf();
         ByteBuf protoBuf = requestPacket.getProtoBuf();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/standard/BaiduRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/standard/BaiduRpcProtocol.java
@@ -222,7 +222,7 @@ public class BaiduRpcProtocol extends AbstractProtocol {
 
     @Override
     public Request decodeRequest(Object packet) throws Exception {
-        Request request = this.getRequest();
+        Request request = this.createRequest();
         BaiduRpcDecodePacket requestPacket = (BaiduRpcDecodePacket) packet;
         ByteBuf metaBuf = requestPacket.getMetaBuf();
         ByteBuf protoAndAttachmentBuf = requestPacket.getProtoAndAttachmentBuf();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -231,6 +231,13 @@ public class RpcServer {
         registerService(service, null, serverOptions);
     }
 
+    /**
+     * register service which can be accessed by client
+     * @param service the service object which implement rpc interface.
+     * @param namingOptions register center info
+     * @param serverOptions service own custom RpcServerOptions
+     *                      if not null, the service will not use the shared thread pool.
+     */
     public void registerService(Object service, NamingOptions namingOptions, RpcServerOptions serverOptions) {
         serviceList.add(service);
         RegisterInfo registerInfo = new RegisterInfo();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
@@ -62,6 +62,8 @@ public class RpcServerOptions {
     private int ioThreadNum = Runtime.getRuntime().availableProcessors();
     // real work threads
     private int workThreadNum = Runtime.getRuntime().availableProcessors();
+    // customized thread num, default value 20
+    private int customizedWorkThreadNum = 20;
     // The max size
     private int maxSize = Integer.MAX_VALUE;
     // server protocol type

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServerOptions.java
@@ -62,8 +62,6 @@ public class RpcServerOptions {
     private int ioThreadNum = Runtime.getRuntime().availableProcessors();
     // real work threads
     private int workThreadNum = Runtime.getRuntime().availableProcessors();
-    // customized thread num, default value 20
-    private int customizedWorkThreadNum = 20;
     // The max size
     private int maxSize = Integer.MAX_VALUE;
     // server protocol type

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/ServiceManager.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/ServiceManager.java
@@ -64,6 +64,7 @@ public class ServiceManager {
         Method[] methods = clazz.getDeclaredMethods();
         registerService(methods, service, threadPool);
     }
+
     public void registerService(Class targetClass, Object service, ThreadPool threadPool) {
         Class[] interfaces = targetClass.getInterfaces();
         if (interfaces.length != 1) {
@@ -74,6 +75,7 @@ public class ServiceManager {
         Method[] methods = clazz.getDeclaredMethods();
         registerService(methods, service, threadPool);
     }
+
     protected void registerService(Method[] methods, Object service, ThreadPool threadPool) {
         for (Method method : methods) {
             RpcMethodInfo methodInfo;

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/ServiceManager.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/ServiceManager.java
@@ -20,6 +20,8 @@ import com.baidu.brpc.JprotobufRpcMethodInfo;
 import com.baidu.brpc.ProtobufRpcMethodInfo;
 import com.baidu.brpc.RpcMethodInfo;
 import com.baidu.brpc.utils.ProtobufUtils;
+import com.baidu.brpc.utils.ThreadPool;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +54,7 @@ public class ServiceManager {
         this.serviceMap = new HashMap<String, RpcMethodInfo>();
     }
 
-    public void registerService(Object service) {
+    public void registerService(Object service, ThreadPool threadPool) {
         Class[] interfaces = service.getClass().getInterfaces();
         if (interfaces.length != 1) {
             LOG.error("service must implement one interface only");
@@ -60,9 +62,9 @@ public class ServiceManager {
         }
         Class clazz = interfaces[0];
         Method[] methods = clazz.getDeclaredMethods();
-        registerService(methods, service);
+        registerService(methods, service, threadPool);
     }
-    public void registerService(Class targetClass, Object service) {
+    public void registerService(Class targetClass, Object service, ThreadPool threadPool) {
         Class[] interfaces = targetClass.getInterfaces();
         if (interfaces.length != 1) {
             LOG.error("service must implement one interface only");
@@ -70,9 +72,9 @@ public class ServiceManager {
         }
         Class clazz = interfaces[0];
         Method[] methods = clazz.getDeclaredMethods();
-        registerService(methods, service);
+        registerService(methods, service, threadPool);
     }
-    protected void registerService(Method[] methods, Object service) {
+    protected void registerService(Method[] methods, Object service, ThreadPool threadPool) {
         for (Method method : methods) {
             RpcMethodInfo methodInfo;
             ProtobufUtils.MessageType messageType = ProtobufUtils.getMessageType(method);
@@ -84,6 +86,7 @@ public class ServiceManager {
                 methodInfo = new RpcMethodInfo(method);
             }
             methodInfo.setTarget(service);
+            methodInfo.setThreadPool(threadPool);
             registerService(methodInfo);
             LOG.info("register service, serviceName={}, methodName={}",
                     methodInfo.getServiceName(), methodInfo.getMethodName());

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerChannelIdleHandler.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerChannelIdleHandler.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * @author wenweihu86
  */
 public class RpcServerChannelIdleHandler extends ChannelDuplexHandler {
-
     private static final Logger LOG = LoggerFactory.getLogger(RpcServerChannelIdleHandler.class);
 
     @Override

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerHandler.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerHandler.java
@@ -62,12 +62,12 @@ public class RpcServerHandler extends SimpleChannelInboundHandler<Object> {
         int len = msg.readableBytes();
         if (len > 0) {
             channelInfo.getRecvBuf().addBuffer(msg.retain());
-            ServerWorkTask[] tasks = new ServerWorkTask[64];
+            DecodeWorkTask[] tasks = new DecodeWorkTask[64];
             int i = 0;
             while (channelInfo.getRecvBuf().readableBytes() > 0) {
                 try {
                     Object packet = decodeHeader(ctx, channelInfo, channelInfo.getRecvBuf());
-                    ServerWorkTask task = new ServerWorkTask(rpcServer, packet, channelInfo.getProtocol(),
+                    DecodeWorkTask task = new DecodeWorkTask(rpcServer, packet, channelInfo.getProtocol(),
                             ctx);
                     tasks[i++] = task;
                     if (i == 64) {
@@ -84,6 +84,7 @@ public class RpcServerHandler extends SimpleChannelInboundHandler<Object> {
             }
             if (i > 0) {
                 rpcServer.getThreadPool().submit(tasks, 0, i);
+
             }
         }
     }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerHandler.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/RpcServerHandler.java
@@ -67,8 +67,7 @@ public class RpcServerHandler extends SimpleChannelInboundHandler<Object> {
             while (channelInfo.getRecvBuf().readableBytes() > 0) {
                 try {
                     Object packet = decodeHeader(ctx, channelInfo, channelInfo.getRecvBuf());
-                    DecodeWorkTask task = new DecodeWorkTask(rpcServer, packet, channelInfo.getProtocol(),
-                            ctx);
+                    DecodeWorkTask task = new DecodeWorkTask(rpcServer, packet, channelInfo.getProtocol(), ctx);
                     tasks[i++] = task;
                     if (i == 64) {
                         rpcServer.getThreadPool().submit(tasks, 0, i);

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/ServerWorkTask.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/handler/ServerWorkTask.java
@@ -16,39 +16,19 @@
 
 package com.baidu.brpc.server.handler;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
-
 import java.lang.reflect.InvocationTargetException;
 
 import com.baidu.brpc.Controller;
-import com.baidu.brpc.exceptions.RpcException;
 import com.baidu.brpc.interceptor.DefaultInterceptorChain;
 import com.baidu.brpc.interceptor.InterceptorChain;
 import com.baidu.brpc.protocol.Protocol;
 import com.baidu.brpc.protocol.Request;
 import com.baidu.brpc.protocol.Response;
-import com.baidu.brpc.protocol.RpcRequest;
-import com.baidu.brpc.protocol.RpcResponse;
-import com.baidu.brpc.protocol.http.BrpcHttpResponseEncoder;
-import com.baidu.brpc.protocol.http.HttpRpcProtocol;
 import com.baidu.brpc.server.RpcServer;
-import com.baidu.brpc.server.ServerStatus;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -60,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class ServerWorkTask implements Runnable {
     private RpcServer rpcServer;
-    private Object packet;
     private Protocol protocol;
     private Request request;
     private Response response;
@@ -68,10 +47,7 @@ public class ServerWorkTask implements Runnable {
 
     @Override
     public void run() {
-
-        log.info("current thread is: {}", Thread.currentThread().getName());
         Controller controller = null;
-
         if (request != null) {
             request.setChannel(ctx.channel());
             if (request.getRpcMethodInfo().isIncludeController()

--- a/brpc-java-core/src/main/java/com/baidu/brpc/thread/ClientCallBackThreadPoolInstance.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/thread/ClientCallBackThreadPoolInstance.java
@@ -33,7 +33,6 @@ public class ClientCallBackThreadPoolInstance {
      * threadNum only works when thread pool instance create in the first time
      */
     public static ExecutorService getOrCreateInstance(int threadNum) {
-
         if (callbackThreadPool == null) {
             synchronized (ClientCallBackThreadPoolInstance.class) {
                 if (callbackThreadPool == null) {

--- a/brpc-java-core/src/test/java/com/baidu/brpc/protocol/http/HttpJsonProtocolTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/protocol/http/HttpJsonProtocolTest.java
@@ -62,7 +62,7 @@ public class HttpJsonProtocolTest {
     @Test
     public void testDecodeHttpRequest() {
         ServiceManager serviceManager = ServiceManager.getInstance();
-        serviceManager.registerService(new HelloWorldServiceImpl());
+        serviceManager.registerService(new HelloWorldServiceImpl(), null);
         ByteBuf content = Unpooled.wrappedBuffer(new Gson().toJson("hello").getBytes());
 
         FullHttpRequest fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET,

--- a/brpc-java-core/src/test/java/com/baidu/brpc/protocol/http/HttpProtoProtocolTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/protocol/http/HttpProtoProtocolTest.java
@@ -64,7 +64,7 @@ public class HttpProtoProtocolTest {
     @Test
     public void testDecodeHttpRequest() throws Exception {
         ServiceManager serviceManager = ServiceManager.getInstance();
-        serviceManager.registerService(new EchoServiceImpl());
+        serviceManager.registerService(new EchoServiceImpl(), null);
 
         ByteBuf content = Unpooled.wrappedBuffer(encodeBody(Echo.EchoRequest.newBuilder().setMessage("hello").build()));
 

--- a/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NsHeadRpcProtocolProtobufTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/protocol/nshead/NsHeadRpcProtocolProtobufTest.java
@@ -76,7 +76,7 @@ public class NsHeadRpcProtocolProtobufTest {
     public void testDecodeRequestSuccess() throws Exception {
         ServiceManager.getInstance().getServiceMap().clear();
 
-        ServiceManager.getInstance().registerService(new EchoServiceImpl());
+        ServiceManager.getInstance().registerService(new EchoServiceImpl(), null);
         Echo.EchoResponse response = Echo.EchoResponse.newBuilder()
                 .setMessage("hello").build();
 

--- a/brpc-java-core/src/test/java/com/baidu/brpc/server/ServerInitTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/server/ServerInitTest.java
@@ -26,7 +26,6 @@ public class ServerInitTest {
 
         RpcServer rpcServer2 = new RpcServer(8001);
         RpcServerOptions options = new RpcServerOptions();
-        options.setCustomizedWorkThreadNum(10);
         rpcServer2.registerService(new EchoServiceImpl(), options);
         rpcServer2.start();
 
@@ -35,12 +34,11 @@ public class ServerInitTest {
         EchoRequest request = Echo.EchoRequest.newBuilder().setMessage("hello").build();
         echoService.echo(request);
 
-
         int processor = Runtime.getRuntime().availableProcessors();
         ThreadNumStat stat1 = calThreadNum();
         Assert.assertEquals(processor, stat1.ioThreadNum);
         Assert.assertEquals(processor, stat1.workThreadNum);
-        Assert.assertEquals(10, stat1.customizedWorkThreadNum);
+        Assert.assertEquals(processor, stat1.customWorkThreadNum);
 
         rpcServer1.shutdown();
         rpcServer2.shutdown();
@@ -49,7 +47,7 @@ public class ServerInitTest {
 
         Assert.assertEquals(processor, stat2.ioThreadNum);
         Assert.assertEquals(processor, stat2.workThreadNum);
-        Assert.assertEquals(0, stat2.customizedWorkThreadNum);
+        Assert.assertEquals(0, stat2.customWorkThreadNum);
 
     }
 
@@ -68,24 +66,23 @@ public class ServerInitTest {
                 stat.workThreadNum ++;
             } else if (thread.getName().contains("server-acceptor-thread")) {
                 stat.acceptorThreadNum ++;
-            } else if (thread.getName().contains("brpc-customized-work-thread")) {
-                stat.customizedWorkThreadNum ++;
+            } else if (thread.getName().contains("EchoServiceImpl-work-thread")) {
+                stat.customWorkThreadNum ++;
             }
         }
 
         log.info("thread statistic data, ioThreadNum : {}, \n workThreadNum : {}, acceptorThreadNum : {}, "
                         + "customizedWorkThreadNum : {}",
-                stat.ioThreadNum, stat.workThreadNum, stat.acceptorThreadNum, stat.customizedWorkThreadNum);
+                stat.ioThreadNum, stat.workThreadNum, stat.acceptorThreadNum, stat.customWorkThreadNum);
 
         return stat;
     }
 
     public static class ThreadNumStat {
-
         public int ioThreadNum;
         public int workThreadNum;
         public int acceptorThreadNum;
-        public int customizedWorkThreadNum;
+        public int customWorkThreadNum;
     }
 
 }

--- a/brpc-java-core/src/test/java/com/baidu/brpc/server/ServerInitTest.java
+++ b/brpc-java-core/src/test/java/com/baidu/brpc/server/ServerInitTest.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ServerInitTest {
 
     @Test
-    public void testInitServerMultiTimes() {
+    public void testInitServerMultiTimes() throws Exception {
 
         RpcServer rpcServer1 = new RpcServer(8000);
         rpcServer1.registerService(new EchoServiceImpl());
@@ -42,9 +42,9 @@ public class ServerInitTest {
 
         rpcServer1.shutdown();
         rpcServer2.shutdown();
-
+        Thread.sleep(5);
+        
         ThreadNumStat stat2 = calThreadNum();
-
         Assert.assertEquals(processor, stat2.ioThreadNum);
         Assert.assertEquals(processor, stat2.workThreadNum);
         Assert.assertEquals(0, stat2.customWorkThreadNum);

--- a/brpc-java-examples/src/main/java/com/baidu/brpc/example/http/json/RpcServerTest.java
+++ b/brpc-java-examples/src/main/java/com/baidu/brpc/example/http/json/RpcServerTest.java
@@ -13,7 +13,8 @@ public class RpcServerTest {
 
         RpcServerOptions options = new RpcServerOptions();
         RpcServer rpcServer = new RpcServer(port, options);
-        rpcServer.registerService(new EchoServiceImpl());
+        // rpcServer.registerService(new EchoServiceImpl());
+        rpcServer.registerService(new EchoServiceImpl(), options);
         rpcServer.start();
 
         // make server keep running

--- a/brpc-java-examples/src/main/java/com/baidu/brpc/example/http/proto/RpcClientTest.java
+++ b/brpc-java-examples/src/main/java/com/baidu/brpc/example/http/proto/RpcClientTest.java
@@ -26,7 +26,7 @@ public class RpcClientTest {
         RpcClientOptions clientOption = new RpcClientOptions();
         clientOption.setProtocolType(ProtocolType.PROTOCOL_HTTP_PROTOBUF_VALUE);
         clientOption.setWriteTimeoutMillis(1000);
-        clientOption.setReadTimeoutMillis(5000);
+        clientOption.setReadTimeoutMillis(500000);
         clientOption.setLoadBalanceType(LoadBalanceType.WEIGHT.getId());
         clientOption.setMaxTryTimes(1);
 

--- a/brpc-java-examples/src/main/java/com/baidu/brpc/example/spring/server/EchoServiceImpl.java
+++ b/brpc-java-examples/src/main/java/com/baidu/brpc/example/spring/server/EchoServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 @Service("echoServiceImpl")
 @RpcExporter(port = "8012",
+        useSharedThreadPool = false,
         rpcServerOptionsBeanName = "rpcServerOptions",
         interceptorBeanName = "customInterceptor")
 public class EchoServiceImpl implements EchoService {

--- a/brpc-java-spring/src/main/java/com/baidu/brpc/spring/RpcServiceExporter.java
+++ b/brpc-java-spring/src/main/java/com/baidu/brpc/spring/RpcServiceExporter.java
@@ -93,7 +93,7 @@ public class RpcServiceExporter extends RpcServerOptions implements Initializing
         namingOptions.setVersion(version);
         namingOptions.setIgnoreFailOfNamingService(ignoreFailOfNamingService);
         for (Object service : registerServices) {
-            prRpcServer.registerService(service, namingOptions);
+            prRpcServer.registerService(service, namingOptions, null);
         }
         prRpcServer.start();
     }

--- a/brpc-java-spring/src/main/java/com/baidu/brpc/spring/RpcServiceExporter.java
+++ b/brpc-java-spring/src/main/java/com/baidu/brpc/spring/RpcServiceExporter.java
@@ -15,7 +15,10 @@
  */
 package com.baidu.brpc.spring;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.baidu.brpc.interceptor.Interceptor;
 import com.baidu.brpc.naming.NamingOptions;
@@ -24,10 +27,11 @@ import com.baidu.brpc.server.RpcServer;
 import com.baidu.brpc.server.RpcServerOptions;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 
 /**
  * PBRPC exporter for standard PROTOBUF RPC implementation from jprotobuf-rpc-socket.
@@ -37,6 +41,7 @@ import org.springframework.util.CollectionUtils;
  */
 @Setter
 @Getter
+@Slf4j
 public class RpcServiceExporter extends RpcServerOptions implements InitializingBean, DisposableBean {
 
     /** The pr rpc server. */
@@ -62,9 +67,16 @@ public class RpcServiceExporter extends RpcServerOptions implements Initializing
      * if true, naming service will throw exception when register/subscribe exceptions.
      */
     private boolean ignoreFailOfNamingService = false;
-    
-    /** The register services. */
-    private List<Object> registerServices;
+
+    /**
+     * the register services which use default thread pool
+     */
+    private List<Object> registerServices = new ArrayList<Object>();
+
+    /**
+     * the register services which use individual thread pool
+     */
+    private Map<RpcServerOptions, Object> customOptionsServiceMap = new HashMap<RpcServerOptions, Object>();
     
 	/** The interceptor. */
 	private List<Interceptor> interceptors;
@@ -85,16 +97,23 @@ public class RpcServiceExporter extends RpcServerOptions implements Initializing
     @Override
     public void afterPropertiesSet() throws Exception {
         Assert.isTrue(servicePort > 0, "invalid service port: " + servicePort);
-        Assert.isTrue(!CollectionUtils.isEmpty(registerServices), "No register service specified.");
+        if (registerServices.size() == 0 && customOptionsServiceMap.size() == 0) {
+            throw new IllegalArgumentException("No register service specified.");
+        }
         
         prRpcServer = new RpcServer(servicePort, this, interceptors, namingServiceFactory);
         NamingOptions namingOptions = new NamingOptions();
         namingOptions.setGroup(group);
         namingOptions.setVersion(version);
         namingOptions.setIgnoreFailOfNamingService(ignoreFailOfNamingService);
+
         for (Object service : registerServices) {
             prRpcServer.registerService(service, namingOptions, null);
         }
+        for (Map.Entry<RpcServerOptions, Object> entry : customOptionsServiceMap.entrySet()) {
+            prRpcServer.registerService(entry.getValue(), namingOptions, entry.getKey());
+        }
+
         prRpcServer.start();
     }
 

--- a/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
+++ b/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
@@ -84,7 +84,7 @@ public @interface RpcExporter {
     boolean ignoreFailOfNamingService() default false;
 
     /**
-     * true: use the default single instance thread pool
+     * true: use the shared thread pool
      * false: create individual thread pool for register service
      */
     boolean useSharedThreadPool() default true;

--- a/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
+++ b/brpc-java-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
@@ -82,4 +82,10 @@ public @interface RpcExporter {
      * @return true, ignore
      */
     boolean ignoreFailOfNamingService() default false;
+
+    /**
+     * true: use the default single instance thread pool
+     * false: create individual thread pool for register service
+     */
+    boolean useSharedThreadPool() default true;
 }


### PR DESCRIPTION
registered service can set own custom thread pool instead of the shared thread pool.
design:
1. in non-spring environment, add RpcServerOptions to RpcServer.registerService.
2. in spring environment, add useSharedThreadPool for RpcExporter to indicate if use shared thread pool.
