### PR TITLE
Bugfix: Incorrect interfaceName set on RegisterInfo 

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -28,6 +28,7 @@ import com.baidu.brpc.naming.NamingServiceFactoryManager;
 import com.baidu.brpc.naming.RegisterInfo;
 import com.baidu.brpc.spi.ExtensionLoaderManager;
 import com.baidu.brpc.utils.*;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -222,7 +223,8 @@ public class RpcServer {
 
     /**
      * register service which can be accessed by client
-     * @param service the service object which implement rpc interface.
+     *
+     * @param service       the service object which implement rpc interface.
      * @param namingOptions register center info
      * @param serverOptions service own custom RpcServerOptions
      *                      if not null, the service will not use the shared thread pool.
@@ -231,7 +233,11 @@ public class RpcServer {
                                 RpcServerOptions serverOptions) {
         serviceList.add(service);
         RegisterInfo registerInfo = new RegisterInfo();
-        registerInfo.setInterfaceName(service.getClass().getInterfaces()[0].getName());
+        if (targetClass != null) {
+            registerInfo.setInterfaceName(targetClass.getInterfaces()[0].getName());
+        } else {
+            registerInfo.setInterfaceName(service.getClass().getInterfaces()[0].getName());
+        }
         registerInfo.setHost(NetUtils.getLocalAddress().getHostAddress());
         registerInfo.setPort(port);
         if (namingOptions != null) {


### PR DESCRIPTION
When Spring AOP is used, the interfaceName on RegisterInfo should be get from the `targetClass` instead of the `service` object which is a Spring AOP generated dynamic proxy implementing `org.springframework.aop.SpringProxy`.