### PR TITLE
Make group and version naming options effective on service-level

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
@@ -211,6 +211,7 @@ public class RpcClient {
                 subscribeInfo.setVersion(namingOptions.getVersion());
                 subscribeInfo.setIgnoreFailOfNamingService(namingOptions.isIgnoreFailOfNamingService());
                 subscribeInfo.setServiceId(namingOptions.getServiceId());
+                subscribeInfo.setExtra(namingOptions.getExtra());
             }
             List<ServiceInstance> instances = this.namingService.lookup(subscribeInfo);
             instanceProcessor.addInstances(instances);

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingOptions.java
@@ -19,17 +19,25 @@ package com.baidu.brpc.naming;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 @Setter
 @Getter
 public class NamingOptions {
     /**
      * identify different service implementation for the same interface.
+     *
+     * @deprecated use {@link #extra} instead
      */
+    @Deprecated
     private String group = "normal";
 
     /**
      * identify service version.
+     *
+     * @deprecated use {@link #extra} instead
      */
+    @Deprecated
     private String version = "1.0.0";
 
     /**
@@ -42,6 +50,11 @@ public class NamingOptions {
      */
     private String serviceId = "";
 
+    /**
+     * extra {@link NamingService} specific options
+     */
+    private Map<String, String> extra;
+
     public NamingOptions() {
     }
 
@@ -50,5 +63,6 @@ public class NamingOptions {
         this.version = rhs.getVersion();
         this.ignoreFailOfNamingService = rhs.isIgnoreFailOfNamingService();
         this.serviceId = rhs.getServiceId();
+        this.extra = rhs.extra;
     }
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingOptions.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingOptions.java
@@ -26,18 +26,12 @@ import java.util.Map;
 public class NamingOptions {
     /**
      * identify different service implementation for the same interface.
-     *
-     * @deprecated use {@link #extra} instead
      */
-    @Deprecated
     private String group = "normal";
 
     /**
      * identify service version.
-     *
-     * @deprecated use {@link #extra} instead
      */
-    @Deprecated
     private String version = "1.0.0";
 
     /**

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+ * Copyright (c) 2019 Baidu, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,6 +244,7 @@ public class RpcServer {
             registerInfo.setGroup(namingOptions.getGroup());
             registerInfo.setVersion(namingOptions.getVersion());
             registerInfo.setIgnoreFailOfNamingService(namingOptions.isIgnoreFailOfNamingService());
+            registerInfo.setExtra(namingOptions.getExtra());
         }
         ServiceManager serviceManager = ServiceManager.getInstance();
         ThreadPool customThreadPool = threadPool;

--- a/brpc-java-examples/brpc-java-core-examples/src/main/java/com/baidu/brpc/example/spring/server/EchoServiceImpl.java
+++ b/brpc-java-examples/brpc-java-core-examples/src/main/java/com/baidu/brpc/example/spring/server/EchoServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+ * Copyright (c) 2019 Baidu, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ package com.baidu.brpc.example.spring.server;
 import com.baidu.brpc.example.spring.api.EchoRequest;
 import com.baidu.brpc.example.spring.api.EchoResponse;
 import com.baidu.brpc.example.spring.api.EchoService;
+import com.baidu.brpc.spring.annotation.NamingOption;
 import com.baidu.brpc.spring.annotation.RpcExporter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,7 +30,13 @@ import org.springframework.stereotype.Service;
 @RpcExporter(port = "8012",
         useSharedThreadPool = false,
         rpcServerOptionsBeanName = "rpcServerOptions",
-        interceptorBeanName = "customInterceptor")
+        interceptorBeanName = "customInterceptor",
+        extraOptions = {
+                // We can pass extra options to the NamingService
+                // `weight` is just an example here, currently we don't have any NamingService supports weight yet
+                @NamingOption(key = "weight", value = "10")
+        }
+)
 public class EchoServiceImpl implements EchoService {
     private static final Logger LOG = LoggerFactory.getLogger(EchoServiceImpl.class);
 

--- a/brpc-java-examples/brpc-spring-boot-examples/brpc-spring-boot-examples-server/src/main/resources/application.yml
+++ b/brpc-java-examples/brpc-spring-boot-examples/brpc-spring-boot-examples-server/src/main/resources/application.yml
@@ -9,6 +9,9 @@ brpc:
       group: "normal"
       version: 2.0.0
       ignoreFailOfNamingService: false
+      extra:
+        - key: weight
+          value: 10
     server:
       port: 8002
       workThreadNum: 1

--- a/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
+++ b/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
@@ -276,30 +276,7 @@ public class SpringBootAnnotationResolver extends AbstractAnnotationParserCallba
         }
 
         // naming options
-        NamingOptions namingOptions;
-        if (brpcConfig.getNaming() != null) {
-            // defaults to global NamingOptions
-            namingOptions = new NamingOptions(brpcConfig.getNaming());
-        } else {
-            namingOptions = new NamingOptions();
-        }
-        // Populate NamingOptions from the annotation
-        if (!rpcExporter.group().isEmpty()) {
-            namingOptions.setGroup(rpcExporter.group());
-        }
-        if (!rpcExporter.version().isEmpty()) {
-            namingOptions.setVersion(rpcExporter.version());
-        }
-        if (rpcExporter.extraOptions().length > 0) {
-            namingOptions.setExtra(new HashMap<String, String>());
-            for (int i = 0; i < rpcExporter.extraOptions().length; i++) {
-                NamingOption opt = rpcExporter.extraOptions()[i];
-                namingOptions.getExtra().put(opt.key(), opt.value());
-            }
-        }
-        namingOptions.setIgnoreFailOfNamingService(rpcExporter.ignoreFailOfNamingService());
-        rpcServiceExporter.getServiceNamingOptions().put(bean, namingOptions);
-
+        rpcServiceExporter.getServiceNamingOptions().put(bean, brpcConfig.getNaming());
 
         if (brpcConfig.getServer() != null && brpcConfig.getServer().isUseSharedThreadPool()) {
             rpcServiceExporter.getCustomOptionsServiceMap().put(brpcConfig.getServer(), bean);

--- a/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
+++ b/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
@@ -261,6 +261,9 @@ public class SpringBootAnnotationResolver extends AbstractAnnotationParserCallba
             portMappingExporters.put(port, rpcServiceExporter);
             rpcServiceExporter.setServicePort(port);
             rpcServiceExporter.copyFrom(brpcConfig.getServer());
+            if (brpcConfig.getNaming() != null) {
+                rpcServiceExporter.setNamingServiceUrl(brpcConfig.getNaming().getNamingServiceUrl());
+            }
         }
 
         // interceptor

--- a/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/NamingOption.java
+++ b/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/NamingOption.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Baidu, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.baidu.brpc.spring.annotation;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Extra options for {@link com.baidu.brpc.naming.NamingService}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NamingOption {
+    /**
+     * Key of the option
+     */
+    String key() default "";
+
+    /**
+     * Value of the option
+     */
+    String value() default "";
+}

--- a/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
+++ b/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
@@ -59,18 +59,12 @@ public @interface RpcExporter {
 
     /**
      * Group for naming service
-     *
-     * @deprecated Use {@link #extraOptions()} instead
      */
-    @Deprecated
     String group() default "normal";
 
     /**
      * Version for naming service
-     *
-     * @deprecated Use {@link #extraOptions()} instead
      */
-    @Deprecated
     String version() default "1.0.0";
 
     /**

--- a/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
+++ b/brpc-spring/src/main/java/com/baidu/brpc/spring/annotation/RpcExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Baidu, Inc. All Rights Reserved.
+ * Copyright (c) 2019 Baidu, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package com.baidu.brpc.spring.annotation;
 
+import com.baidu.brpc.spring.RpcServiceExporter;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import com.baidu.brpc.spring.RpcServiceExporter;
 
 /**
  * Annotation publish for {@link RpcServiceExporter}.
@@ -42,14 +42,14 @@ public @interface RpcExporter {
      * @return the string
      */
     String port() default "8080";
-    
+
     /**
      * bean name of RPC server options bean type must be {@link com.baidu.brpc.server.RpcServerOptions}.
      *
      * @return the string
      */
     String rpcServerOptionsBeanName() default "";
-    
+
     /**
      * bean name of RPC interceptor bean type must be {@link com.baidu.brpc.interceptor.Interceptor}.
      *
@@ -58,15 +58,19 @@ public @interface RpcExporter {
     String interceptorBeanName() default "";
 
     /**
-     * group for naming service
+     * Group for naming service
      *
+     * @deprecated Use {@link #extraOptions()} instead
      */
+    @Deprecated
     String group() default "normal";
 
     /**
-     * version for naming service
+     * Version for naming service
      *
+     * @deprecated Use {@link #extraOptions()} instead
      */
+    @Deprecated
     String version() default "1.0.0";
 
     /**
@@ -81,4 +85,12 @@ public @interface RpcExporter {
      * false: create individual thread pool for register service
      */
     boolean useSharedThreadPool() default true;
+
+    /**
+     * Extra naming options. This option is effective on service-scope.
+     * <p>
+     * This config may have different behavior depending on which NamingService is used,
+     * consult documentation of the specific {@link com.baidu.brpc.naming.NamingService} for detailed usage.
+     */
+    NamingOption[] extraOptions() default {};
 }


### PR DESCRIPTION
Currently group and version naming options are effective on `RpcServer` level. This cause a problem that we cannot serve services with different groups and versions on the same port. This pull request makes group and version options to be service level.

Adds an extra() key-value array for NamingOptions which can be use to
customizing NamingService. The actual behavior of extra options depends on which NamingService is used. Extra options are effective on service level. 

`StargateZookeeperNamingService` will encode extra options other than `group`, `version` and
`interface` in its registration URI.