### PR TITLE
Bugfix: Stargate service node registration path must be in lowercase

### DIFF
--- a/brpc-java-naming-zookeeper/src/main/java/com/baidu/brpc/naming/zookeeper/StargateZookeeperNamingService.java
+++ b/brpc-java-naming-zookeeper/src/main/java/com/baidu/brpc/naming/zookeeper/StargateZookeeperNamingService.java
@@ -193,10 +193,10 @@ public class StargateZookeeperNamingService extends ZookeeperNamingService {
     }
 
     /**
-     * stargate 注册或者订阅节点时，serviceName 为全小写
+     * stargate 注册或者订阅节点时，整个 Path 为小写
      */
     private String buildParentNodePath(String group, String serviceName, String version) {
-        return "/" + group + ":" + serviceName.toLowerCase() + ":" + version;
+        return ("/" + group + ":" + serviceName + ":" + version).toLowerCase();
     }
 
 


### PR DESCRIPTION
Currently only the service name is converted to lowercase. We should do the same on group and version as well.