### PR TITLE
Bugfix: Stargate client does not handle exception on RpcResponse

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/stargate/StargateRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/stargate/StargateRpcProtocol.java
@@ -178,6 +178,14 @@ public class StargateRpcProtocol extends AbstractProtocol {
             try {
                 Response response = new RpcResponse();
                 response.setResult(rpcResponse.getResult());
+                if (rpcResponse.getException() != null) {
+                    if (rpcResponse.getException() instanceof Throwable) {
+                        response.setException((Throwable) rpcResponse.getException());
+                    } else {
+                        throw new IllegalStateException("stargate response contains an exception which"
+                                + "is not a throwable");
+                    }
+                }
                 long correlationId = Long.parseLong(rpcResponse.getId());
                 ChannelInfo channelInfo = ChannelInfo.getClientChannelInfo(ctx.channel());
                 RpcFuture future = channelInfo.removeRpcFuture(correlationId);


### PR DESCRIPTION
Stargate client always complains the following when exception is thrown on the sever side.
```
Caused by: com.baidu.brpc.exceptions.RpcException: unknown error
	at com.baidu.brpc.interceptor.LoadBalanceInterceptor.aroundProcess(LoadBalanceInterceptor.java:66) ~[brpc-java-2.5.2.jar:na]
	at com.baidu.brpc.interceptor.DefaultInterceptorChain.intercept(DefaultInterceptorChain.java:43) ~[brpc-java-2.5.2.jar:na]
	at com.baidu.brpc.interceptor.AbstractInterceptor.aroundProcess(AbstractInterceptor.java:35) ~[brpc-java-2.5.2.jar:na]
	at com.baidu.brpc.interceptor.ClientTraceInterceptor.aroundProcess(ClientTraceInterceptor.java:40) ~[brpc-java-2.5.2.jar:na]
	at com.baidu.brpc.interceptor.DefaultInterceptorChain.intercept(DefaultInterceptorChain.java:43) ~[brpc-java-2.5.2.jar:na]
	at com.baidu.brpc.client.BrpcProxy.intercept(BrpcProxy.java:265) ~[brpc-java-2.5.2.jar:na]
	... 88 common frames omitted
```

