### PR TITLE
Bugfix:`brpc.global.client/server/naming` configs can be omitted now.

### DIFF
--- a/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/config/BrpcProperties.java
+++ b/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/config/BrpcProperties.java
@@ -66,11 +66,20 @@ public class BrpcProperties implements EnvironmentAware {
 
     public BrpcConfig getServiceConfig(Class<?> serviceInterface) {
         BrpcConfig brpcConfig = new BrpcConfig(global);
+        if (brpcConfig.getClient() == null) {
+            brpcConfig.setClient(new RpcClientConfig());
+        }
+        if (brpcConfig.getServer() == null) {
+            brpcConfig.setServer(new RpcServerConfig());
+        }
+        if (brpcConfig.getNaming() == null) {
+            brpcConfig.setNaming(new RpcNamingConfig());
+        }
         String prefix = "brpc.custom." + serviceInterface.getName() + ".";
         Binder binder = Binder.get(environment);
-        binder.bind(camelToKebabCase(prefix + "naming"), Bindable.ofInstance(brpcConfig.getNaming()));
         binder.bind(camelToKebabCase(prefix + "client"), Bindable.ofInstance(brpcConfig.getClient()));
         binder.bind(camelToKebabCase(prefix + "server"), Bindable.ofInstance(brpcConfig.getServer()));
+        binder.bind(camelToKebabCase(prefix + "naming"), Bindable.ofInstance(brpcConfig.getNaming()));
         rewriteMap(brpcConfig.getNaming().getExtra());
         return brpcConfig;
     }


### PR DESCRIPTION
Default configs are not correctly handled by `BrpcProperties`. User has to specify all `brpc.global.client/server/naming` configs even if he/she just wants to use the defaults.