### PR TITLE
add destory method for NamingService

### DIFF
--- a/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/client/RpcClient.java
@@ -255,6 +255,7 @@ public class RpcClient {
         if (stop.compareAndSet(false, true)) {
             if (namingService != null) {
                 namingService.unsubscribe(subscribeInfo);
+                namingService.destroy();
             }
             if (instanceProcessor != null) {
                 instanceProcessor.stop();

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/DnsNamingService.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/DnsNamingService.java
@@ -117,4 +117,8 @@ public class DnsNamingService implements NamingService {
     public String getHostPort() {
         return hostPort;
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/FileNamingService.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/FileNamingService.java
@@ -139,4 +139,8 @@ public class FileNamingService implements NamingService {
     @Override
     public void unregister(RegisterInfo registerInfo) {
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/ListNamingService.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/ListNamingService.java
@@ -68,4 +68,8 @@ public class ListNamingService implements NamingService {
     @Override
     public void unregister(RegisterInfo registerInfo) {
     }
+
+    @Override
+    public void destroy() {
+    }
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingService.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/naming/NamingService.java
@@ -54,4 +54,9 @@ public interface NamingService {
      * @param registerInfo service/group/version info
      */
     void unregister(RegisterInfo registerInfo);
+
+    /**
+     * 销毁服务注册发现client，client或server实例销毁时调用
+     */
+    void destroy();
 }

--- a/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcProtocol.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/protocol/http/HttpRpcProtocol.java
@@ -353,7 +353,14 @@ public class HttpRpcProtocol extends AbstractProtocol {
             long correlationId = parseCorrelationId(httpRequest.headers().get(CORRELATION_ID), null);
             httpRequest.setCorrelationId(correlationId);
 
-            String contentTypeAndEncoding = httpRequest.headers().get(HttpHeaderNames.CONTENT_TYPE).toLowerCase();
+            String contentTypeAndEncoding = httpRequest.headers().get(HttpHeaderNames.CONTENT_TYPE);
+            if (StringUtils.isBlank(contentTypeAndEncoding)) {
+                String errMsg = String.format("content-type is null, uri:%s", httpRequest.uri());
+                LOG.warn(errMsg);
+                httpRequest.setException(new RpcException(RpcException.SERVICE_EXCEPTION, errMsg));
+                return httpRequest;
+            }
+            contentTypeAndEncoding = contentTypeAndEncoding.toLowerCase();
             String[] splits = StringUtils.split(contentTypeAndEncoding, ";");
             int protocolType = HttpRpcProtocol.parseProtocolType(splits[0]);
             String encoding = this.encoding;

--- a/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
+++ b/brpc-java-core/src/main/java/com/baidu/brpc/server/RpcServer.java
@@ -353,6 +353,7 @@ public class RpcServer {
                 for (RegisterInfo registerInfo : registerInfoList) {
                     namingService.unregister(registerInfo);
                 }
+                namingService.destroy();
             }
             if (bossGroup != null && !rpcServerOptions.isGlobalThreadPoolSharing()) {
                 bossGroup.shutdownGracefully().syncUninterruptibly();

--- a/brpc-java-naming-consul/src/main/java/com/baidu/brpc/naming/consul/ConsulNamingService.java
+++ b/brpc-java-naming-consul/src/main/java/com/baidu/brpc/naming/consul/ConsulNamingService.java
@@ -134,6 +134,7 @@ public class ConsulNamingService implements NamingService {
                 ConsulConstants.HEARTBEAT_CIRCLE, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public void destroy() {
         serviceIds.clear();
         timer.stop();

--- a/brpc-java-naming-zookeeper/src/main/java/com/baidu/brpc/naming/zookeeper/ZookeeperNamingService.java
+++ b/brpc-java-naming-zookeeper/src/main/java/com/baidu/brpc/naming/zookeeper/ZookeeperNamingService.java
@@ -254,6 +254,12 @@ public class ZookeeperNamingService implements NamingService {
         }
     }
 
+    @Override
+    public void destroy() {
+        client.close();
+        timer.stop();
+    }
+
     public String getSubscribePath(SubscribeInfo subscribeInfo) {
         StringBuilder sb = new StringBuilder();
         sb.append("/");

--- a/spring-cloud-brpc/src/main/java/com/baidu/brpc/spring/cloud/SpringCloudNamingService.java
+++ b/spring-cloud-brpc/src/main/java/com/baidu/brpc/spring/cloud/SpringCloudNamingService.java
@@ -106,4 +106,8 @@ public class SpringCloudNamingService implements NamingService {
     @Override
     public void unregister(RegisterInfo registerInfo) {
     }
+
+    @Override
+    public void destroy() {
+    }
 }


### PR DESCRIPTION
1、fix http content-type null exception
2、add destory method for NamingService, and is called when RpcClient or RpcServer has stopped.