### PR TITLE
Fix NPE in BrpcThreadPoolManager.java while using synchronized

### DIFF
--- a/brpc-java-communication/src/main/java/com/baidu/brpc/thread/BrpcThreadPoolManager.java
+++ b/brpc-java-communication/src/main/java/com/baidu/brpc/thread/BrpcThreadPoolManager.java
@@ -45,7 +45,7 @@ public class BrpcThreadPoolManager {
                                                   int threadNum, int ioEventType) {
         if (isSharing) {
             if (defaultIoThreadPool == null) {
-                synchronized (defaultIoThreadPool) {
+                synchronized (BrpcThreadPoolManager.class) {
                     if (defaultIoThreadPool == null) {
                         defaultIoThreadPool = createClientIoThreadPool(
                                 threadNum, "brpc-client-io-thread-default", ioEventType);
@@ -84,7 +84,7 @@ public class BrpcThreadPoolManager {
     public ThreadPool getOrCreateClientWorkThreadPool(String serviceName, boolean isSharing, int threadNum) {
         if (isSharing) {
             if (defaultWorkThreadPool == null) {
-                synchronized (defaultWorkThreadPool) {
+                synchronized (BrpcThreadPoolManager.class) {
                     if (defaultWorkThreadPool == null) {
                         defaultWorkThreadPool = new ThreadPool(threadNum,
                                 new CustomThreadFactory("brpc-client-work-thread-default"));


### PR DESCRIPTION
I met following NPE while using Version 3.0.1. `synchronized` keyword is not working with `null`。
```
2020-07-26 18:22:50,387 [main] WARN  CLIENT - Caught exception:java.lang.NullPointerException
        at com.baidu.brpc.thread.BrpcThreadPoolManager.getOrCreateClientWorkThreadPool(BrpcThreadPoolManager.java:87)
        at com.baidu.brpc.client.channel.BootstrapManager.createBooStrap(BootstrapManager.java:78)
        at com.baidu.brpc.client.channel.BootstrapManager.getOrCreateBootstrap(BootstrapManager.java:48)
        at com.baidu.brpc.client.channel.AbstractBrpcChannel.<init>(AbstractBrpcChannel.java:40)
        at com.baidu.brpc.client.channel.BrpcPooledChannel.<init>(BrpcPooledChannel.java:52)
        at com.baidu.brpc.client.channel.BrpcChannelFactory.createChannel(BrpcChannelFactory.java:10)
        at com.baidu.brpc.client.CommunicationClient.<init>(CommunicationClient.java:67)
        at com.baidu.brpc.client.InterceptCommunicationClient.<init>(InterceptCommunicationClient.java:22)
        at com.baidu.brpc.naming.NamingServiceProcessor.addInstance(NamingServiceProcessor.java:112)
        at com.baidu.brpc.naming.NamingServiceProcessor.addInstances(NamingServiceProcessor.java:102)
        at com.baidu.brpc.naming.NamingServiceProcessor.<init>(NamingServiceProcessor.java:59)
        at com.baidu.brpc.client.RpcClient.setServiceInterface(RpcClient.java:155)
        at com.baidu.brpc.client.BrpcProxy.getProxy(BrpcProxy.java:130)
        at com.baidu.brpc.client.BrpcProxy.getProxy(BrpcProxy.java:126)
```