### PR TITLE
Issue-188 Upgrade Netty-all from 4.1.42.Final to 4.4.51.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.42.Final</netty.version>
+        <netty.version>4.1.51.Final</netty.version>
         <protobuf.version>2.5.0</protobuf.version>
         <jprotobuf.version>1.11.11</jprotobuf.version>
         <jprotobuf.plugin.version>1.2.15</jprotobuf.plugin.version>


### PR DESCRIPTION
Netty 4.4.42 has some known security issues as following:

- [CVE-2019-20444](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20444) , before 4.1.44
- [CVE-2019-20445](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20445), before 4.1.44
- [CVE-2020-11612](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11612), before 4.1.46

This PR aims to bring the bug fixes from the latest netty-all.