### PR TITLE
field type error when create rpcproxy,fix it

### DIFF
--- a/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
+++ b/brpc-spring-boot-starter/src/main/java/com/baidu/brpc/spring/boot/autoconfigure/SpringBootAnnotationResolver.java
@@ -362,7 +362,7 @@ public class SpringBootAnnotationResolver extends AbstractAnnotationParserCallba
                 Interceptor interceptor = beanFactory.getBean(interceptorBeanName, Interceptor.class);
                 customInterceptors.add(interceptor);
             }
-            values.addPropertyValue("interceptors", Arrays.asList(customInterceptors));
+            values.addPropertyValue("interceptors", customInterceptors);
         }
 
         beanDef.setPropertyValues(values);


### PR DESCRIPTION
value type not match field type for field "interceptors"  when create rpcproxy ,
required List<Interceptor> but found  List<List<Interceptor>>, now fix it.